### PR TITLE
Add `release.yml` GitHub Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
-    - name: Test
-      run: make test
+#    - name: Test
+#      run: make test
 
     - name: Build
       run: make build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
-#    - name: Test
-#      run: make test
+    - name: Test
+      run: make test
 
     - name: Build
       run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
           # The action runs in a Docker container
           # Inside the Docker container, the current repo will be available at `github.workspace` path
           OUTPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_
+          # Since this fork uses `mumoshu/terraform-provider-helmfile` Go imports, we provide WORKING_DIR to the action.
+          # The action will copy the current repo into WORKING_DIR, which has GOPATH structure.
+          WORKING_DIR: ${{ github.workspace }}/../src/github.com/mumoshu/terraform-provider-helmfile
+          GOPATH: ${{ github.workspace }}/../
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Build Go binaries'
         uses: cloudposse/actions/go/build@update-go-build
         env:
-          # OSes and architectures for `gox` to build for
+          # Architectures for `gox` to build for
           GOX_OSARCH: >-
             windows/386
             windows/amd64
@@ -36,13 +36,7 @@ jobs:
             freebsd/386
             openbsd/386
             openbsd/amd64
-          # The action runs in a Docker container
-          # Inside the Docker container, the current repo will be available at `github.workspace` path
           OUTPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_
-          # Since this fork uses `mumoshu/terraform-provider-helmfile` Go imports, we provide WORKING_DIR to the action.
-          # The action will copy the current repo into WORKING_DIR, which has GOPATH structure.
-      #          WORKING_DIR: ${{ github.workspace }}/../src/github.com/mumoshu/terraform-provider-helmfile
-      #          GOPATH: ${{ github.workspace }}/..
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Build Go binaries
       - name: 'Build Go binaries'
-        uses: cloudposse/actions/go/build@0.2.0
+        uses: cloudposse/actions/go/build@update-go-build
         env:
           # OSes and architectures for `gox` to build for
           GOX_OSARCH: >-
@@ -42,7 +42,7 @@ jobs:
           # Since this fork uses `mumoshu/terraform-provider-helmfile` Go imports, we provide WORKING_DIR to the action.
           # The action will copy the current repo into WORKING_DIR, which has GOPATH structure.
           WORKING_DIR: ${{ github.workspace }}/../src/github.com/mumoshu/terraform-provider-helmfile
-          GOPATH: ${{ github.workspace }}/../
+          GOPATH: ${{ github.workspace }}/..
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
           OUTPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_
           # Since this fork uses `mumoshu/terraform-provider-helmfile` Go imports, we provide WORKING_DIR to the action.
           # The action will copy the current repo into WORKING_DIR, which has GOPATH structure.
-          WORKING_DIR: ${{ github.workspace }}/../src/github.com/mumoshu/terraform-provider-helmfile
-          GOPATH: ${{ github.workspace }}/..
+      #          WORKING_DIR: ${{ github.workspace }}/../src/github.com/mumoshu/terraform-provider-helmfile
+      #          GOPATH: ${{ github.workspace }}/..
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Build Go binaries'
         uses: cloudposse/actions/go/build@update-go-build
         env:
-          # Architectures for `gox` to build for
+          # Architectures to build for
           GOX_OSARCH: >-
             windows/386
             windows/amd64
@@ -36,11 +36,11 @@ jobs:
             freebsd/386
             openbsd/386
             openbsd/amd64
-          OUTPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_
+          OUTPUT_PATH: ${{ github.workspace }}/release/terraform-provider-helmfile_
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'
         uses: cloudposse/actions/github/release-assets@0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_*
+          INPUT_PATH: ${{ github.workspace }}/release/terraform-provider-helmfile_*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: 'Build Go binaries and attach to GitHub Release'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: 'Build Go binaries and attach to GitHub Release'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repo
+      - name: 'Checkout'
+        uses: actions/checkout@v1
+
+      # Build Go binaries
+      - name: 'Build Go binaries'
+        uses: cloudposse/actions/go/build@0.2.0
+        env:
+          # OSes and architectures for `gox` to build for
+          GOX_OSARCH: >-
+            windows/386
+            windows/amd64
+            freebsd/arm
+            netbsd/386
+            netbsd/amd64
+            netbsd/arm
+            linux/s390x
+            linux/arm
+            darwin/386
+            darwin/amd64
+            linux/386
+            linux/amd64
+            freebsd/amd64
+            freebsd/386
+            openbsd/386
+            openbsd/amd64
+          # The action runs in a Docker container
+          # Inside the Docker container, the current repo will be available at `github.workspace` path
+          OUTPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_
+
+      # Attach Go binaries to GitHub Release
+      - name: 'Attach Go binaries to GitHub Release'
+        uses: cloudposse/actions/github/release-assets@0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PATH: ${{ github.workspace }}/release/terraform_provider_helmfile_*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Build Go binaries
       - name: 'Build Go binaries'
-        uses: cloudposse/actions/go/build@update-go-build
+        uses: cloudposse/actions/go/build@0.7.0
         env:
           # Architectures to build for
           GOX_OSARCH: >-
@@ -40,7 +40,7 @@ jobs:
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach Go binaries to GitHub Release'
-        uses: cloudposse/actions/github/release-assets@0.2.0
+        uses: cloudposse/actions/github/release-assets@0.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_PATH: ${{ github.workspace }}/release/terraform-provider-helmfile_*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mumoshu/terraform-provider-helmfile
 
-go 1.12
+go 1.13
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
## what
* Add `release.yml` GitHub Action

## why
* Build Go binaries for different architectures and attach to GitHub release
* To be able to download Go binaries and install them into `/terraform.d/plugins` to activate the provider 

## references
* https://github.com/cloudposse/terraform-provider-helmfile/releases/tag/0.0.0.1
* https://github.com/cloudposse/actions/tree/master/go/build
* https://github.com/cloudposse/actions/tree/master/github/release-assets
