### PR TITLE
Add --concurrency flag for release sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ resource "helmfile_release_set" "mystack" {
 
     working_directory = path.module
 
+    # Maximum number of concurrent helm processes to run, 0 is unlimited (0 is a default value)
+    concurrency = 0
+
     # Helmfile environment name to deploy
     # Default: default
     environment = "prod"

--- a/pkg/tfhelmfile/resource_release_set.go
+++ b/pkg/tfhelmfile/resource_release_set.go
@@ -282,7 +282,7 @@ func readRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []st
          args := []string{
 		"diff",
 		"--concurrency", strconv.Itoa(fs.Concurrency),
-                  "--detailed-exitcode",
+		"--detailed-exitcode",
 	}
 
 	cmd, err := GenerateCommand(fs, args...)

--- a/pkg/tfhelmfile/resource_release_set.go
+++ b/pkg/tfhelmfile/resource_release_set.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/rs/xid"
@@ -116,7 +117,7 @@ func resourceShellHelmfileReleaseSet() *schema.Resource {
 			KeyConcurrency: {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  false,
+				Default:  0,
 			},
 		},
 	}
@@ -235,10 +236,9 @@ func createRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []
 	printStackTrace(stack)
 
          args := []string{
-		"--concurrency", fs.Concurrency,
+		"apply",
+		"--concurrency", strconv.Itoa(fs.Concurrency),
 	}
-
-	args = append("apply", args)
 
 	cmd, err := GenerateCommand(fs, args...)
 	if err != nil {
@@ -278,11 +278,10 @@ func readRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []st
 	printStackTrace(stack)
 
          args := []string{
-		"--concurrency", fs.Concurrency,
+		"diff",
+		"--concurrency", strconv.Itoa(fs.Concurrency),
                   "--detailed-exitcode",
 	}
-
-	args = append("diff", args)
 
 	cmd, err := GenerateCommand(fs, args...)
 	if err != nil {
@@ -334,10 +333,9 @@ func updateRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []
 	printStackTrace(stack)
 
 	args := []string{
-		"--concurrency", fs.Concurrency,
+		"apply",
+		"--concurrency", strconv.Itoa(fs.Concurrency),
 	}
-
-	args = append("apply", args)
 
 	cmd, err := GenerateCommand(fs, args...)
 	if err != nil {

--- a/pkg/tfhelmfile/resource_release_set.go
+++ b/pkg/tfhelmfile/resource_release_set.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/rs/xid"
@@ -223,6 +224,7 @@ func GenerateCommand(fs *ReleaseSet, additionals ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(fs.Bin, append(args, additionals...)...)
 	cmd.Dir = fs.WorkingDirectory
 	cmd.Env = append(os.Environ(), readEnvironmentVariables(fs.EnvironmentVariables)...)
+	log.Printf("[DEBUG] Cmd: %s", strings.Join(cmd.Args," "))
 	return cmd, nil
 }
 


### PR DESCRIPTION
This MR adds the possibility to set up a maximum number of concurrent helm processes via passing the `--concurrency` flag to the helmfile binary for release sets.

Also, it prints out the resulting command in TF debug mode (when TF_LOG=debug).