### PR TITLE
Always suppress secrets

### DIFF
--- a/pkg/tfhelmfile/resource_release_set.go
+++ b/pkg/tfhelmfile/resource_release_set.go
@@ -240,6 +240,7 @@ func createRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []
 	args := []string{
 		"apply",
 		"--concurrency", strconv.Itoa(fs.Concurrency),
+		"--suppress-secrets",
 	}
 
 	cmd, err := GenerateCommand(fs, args...)
@@ -283,6 +284,7 @@ func readRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []st
 		"diff",
 		"--concurrency", strconv.Itoa(fs.Concurrency),
 		"--detailed-exitcode",
+		"--suppress-secrets",
 	}
 
 	cmd, err := GenerateCommand(fs, args...)
@@ -337,6 +339,7 @@ func updateRs(fs *ReleaseSet, d *schema.ResourceData, meta interface{}, stack []
 	args := []string{
 		"apply",
 		"--concurrency", strconv.Itoa(fs.Concurrency),
+		"--suppress-secrets",
 	}
 
 	cmd, err := GenerateCommand(fs, args...)


### PR DESCRIPTION
This suppresses secrets by default and always.

We can do it configurable as well if needed.

Related to https://github.com/mumoshu/terraform-provider-helmfile/issues/12