### PR TITLE
add parameter releases values

### DIFF
--- a/pkg/helmfile/release_set.go
+++ b/pkg/helmfile/release_set.go
@@ -28,6 +28,7 @@ type ReleaseSet struct {
 	Selector             map[string]interface{}
 	EnvironmentVariables map[string]interface{}
 	WorkingDirectory     string
+	ReleasesValues       map[string]interface{}
 
 	// Kubeconfig is the file path to kubeconfig which is set to the KUBECONFIG environment variable on running helmfile
 	Kubeconfig string
@@ -75,6 +76,7 @@ func NewReleaseSet(d ResourceRead) (*ReleaseSet, error) {
 	}
 
 	f.Values = d.Get(KeyValues).([]interface{})
+	f.ReleasesValues = d.Get(KeyReleasesValues).(map[string]interface{})
 	f.Bin = d.Get(KeyBin).(string)
 	f.WorkingDirectory = d.Get(KeyWorkingDirectory).(string)
 
@@ -169,6 +171,9 @@ func NewCommand(fs *ReleaseSet, args ...string) (*exec.Cmd, error) {
 			return nil, err
 		}
 		flags = append(flags, "--state-values-file", tmpf)
+	}
+	for k, v := range fs.ReleasesValues {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
 	}
 	cmd := exec.Command(*helmfileBin, append(flags, args...)...)
 	cmd.Dir = fs.WorkingDirectory

--- a/pkg/helmfile/resource_release_set.go
+++ b/pkg/helmfile/resource_release_set.go
@@ -22,6 +22,7 @@ const KeyError = "error"
 const KeyApplyOutput = "apply_output"
 const KeyDirty = "dirty"
 const KeyConcurrency = "concurrency"
+const KeyReleasesValues = "releases_values"
 
 const HelmfileDefaultPath = "helmfile.yaml"
 
@@ -132,6 +133,11 @@ var ReleaseSetSchema = map[string]*schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
 		Default:  0,
+	},
+	KeyReleasesValues: {
+		Type:     schema.TypeMap,
+		Optional: true,
+		ForceNew: false,
 	},
 }
 


### PR DESCRIPTION
Thank you always!
This PR proposes to enable the options of helmfile "--set".
I assume control of cronjob's suspend parameter!

e.g. 
```
❯ cat chart/charts/templates/batch.yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: env-batch
spec:
  schedule: "*/1 * * * *"
  suspend: {{ .Values.suspend }}
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: sleep
            image: alpine
            command: ["sh", "-c"]
            args:
            - |
              sleep 10
          restartPolicy: Never

❯ cat chart/charts/values.yaml
suspend: false

❯ helmfile -f helmfile.yaml diff --set suspend=true

-snip-
test, env-batch, CronJob (batch) has been added:
-
+ # Source: test/templates/batch.yaml
+ apiVersion: batch/v1beta1
+ kind: CronJob
+ metadata:
+   name: env-batch
+ spec:
+   schedule: "*/1 * * * *"
+   suspend: true
+   jobTemplate:
+     spec:
+       template:
+         spec:
+           containers:
+           - name: sleep
+             image: alpine
+             command: ["sh", "-c"]
+             args:
+             - |
+               sleep 10
+           restartPolicy: Never
-snip-
```
