### PR TITLE
fix: Pass the options `--set` only when running `helmfile apply` and `helmfile diff`.

### DIFF
--- a/pkg/helmfile/release_set.go
+++ b/pkg/helmfile/release_set.go
@@ -686,6 +686,10 @@ func UpdateReleaseSet(fs *ReleaseSet, d ResourceReadWrite) error {
 		"--suppress-secrets",
 	}
 
+	for k, v := range fs.ReleasesValues {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
+	}
+
 	cmd, err := NewCommand(fs, args...)
 	if err != nil {
 		return err

--- a/pkg/helmfile/release_set.go
+++ b/pkg/helmfile/release_set.go
@@ -172,9 +172,6 @@ func NewCommand(fs *ReleaseSet, args ...string) (*exec.Cmd, error) {
 		}
 		flags = append(flags, "--state-values-file", tmpf)
 	}
-	for k, v := range fs.ReleasesValues {
-		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
-	}
 	cmd := exec.Command(*helmfileBin, append(flags, args...)...)
 	cmd.Dir = fs.WorkingDirectory
 	cmd.Env = append(os.Environ(), readEnvironmentVariables(fs.EnvironmentVariables, "KUBECONFIG")...)
@@ -228,6 +225,10 @@ func CreateReleaseSet(fs *ReleaseSet, d ResourceReadWrite) error {
 		"apply",
 		"--concurrency", strconv.Itoa(fs.Concurrency),
 		"--suppress-secrets",
+	}
+
+	for k, v := range fs.ReleasesValues {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	cmd, err := NewCommand(fs, args...)
@@ -378,6 +379,10 @@ func runDiff(fs *ReleaseSet, opts ...DiffOption) (*State, error) {
 		"--detailed-exitcode",
 		"--suppress-secrets",
 		"--context", "3",
+	}
+
+	for k, v := range fs.ReleasesValues {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	if options.DryRun {


### PR DESCRIPTION
I found a little bug.
When using the parameter `relases_values`, I got the following error... 😭 

- terraform plan output
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

-snip-

Error: diffing release set: %!w(<nil>)

  on cluster.tf line 115, in resource "helmfile_release_set" "blueFirst":
 115: resource "helmfile_release_set" "blueFirst" {
```

The cause was running "--set" on an unsupported subcommand.
e.g. `helmfile version` / `helmfile build` ...etc

- terraform plan debug
```
2020-09-13T02:39:02.453+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0:  DiffOutput: ApplyOutput: Environment:default Selector:map[] EnvironmentVariables:map[KUBECONFIG:/var/folders/8g/cj5brb115g1369knxjwyb_351xk4ng/T/tf-eksctl-kubeconfig144601874] WorkingDirectory: ReleasesValues:map[suspend:false] Kubeconfig: Concurrency:0 Version: HelmVersion: HelmDiffVersion:}
.yaml --no-color --helm-binary helm --environment default version --set suspend=false
2020-09-13T02:39:02.453+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: 2020/09/13 02:39:02 [DEBUG] Locking ""
2020-09-13T02:39:02.453+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: 2020/09/13 02:39:02 [DEBUG] Locked ""
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: 2020/09/13 02:39:02 [DEBUG] helmfile command output: "Incorrect Usage: flag provided but not defined: -set
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0:
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: NAME:
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0:    helmfile version - Show the version for Helmfile.
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0:
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: USAGE:
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0:    helmfile version [command]
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: flag provided but not defined: -set
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: "
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: 2020/09/13 02:39:02 [DEBUG] Unlocking ""
2020-09-13T02:39:02.815+0900 [DEBUG] plugin.terraform-provider-helmfile_v0.7.0: 2020/09/13 02:39:02 [DEBUG] Unlocked ""
2020/09/13 02:39:02 [ERROR] eval: *terraform.EvalDiff, err: diffing release set: %!w(<nil>)
2020/09/13 02:39:02 [ERROR] eval: *terraform.EvalSequence, err: diffing release set: %!w(<nil>)

Error: diffing release set: %!w(<nil>)
```

So, I modified code to pass the options only when running `helmfile apply` and `helmfile diff`.

- related PR
https://github.com/mumoshu/terraform-provider-helmfile/pull/35