### PR TITLE
breaking: Make kubeconfig path required

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup helmfile
       uses: mamezou-tech/setup-helmfile@v0.4.0
       with:
-        helmfile-version: "v0.126.0"
+        helmfile-version: "v0.128.1"
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.0.0

--- a/pkg/helmfile/resource_release.go
+++ b/pkg/helmfile/resource_release.go
@@ -107,9 +107,8 @@ func resourceHelmfileRelease() *schema.Resource {
 			},
 			KeyKubeconfig: {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: false,
-				Default:  "",
 			},
 			KeyKubecontext: {
 				Type:     schema.TypeString,

--- a/pkg/helmfile/resource_release_set.go
+++ b/pkg/helmfile/resource_release_set.go
@@ -63,9 +63,8 @@ var ReleaseSetSchema = map[string]*schema.Schema{
 	},
 	KeyKubeconfig: {
 		Type:     schema.TypeString,
-		Optional: true,
+		Required: true,
 		ForceNew: false,
-		Default:  "",
 	},
 	KeyPath: {
 		Type:     schema.TypeString,
@@ -207,6 +206,12 @@ func resourceReleaseSetDiff(d *schema.ResourceDiff, meta interface{}) error {
 	kubeconfig, err := getKubeconfig(fs)
 	if err != nil {
 		return fmt.Errorf("getting kubeconfig: %w", err)
+	}
+
+	if fs.Kubeconfig == "" {
+		logf("Skipping helmfile-diff due to that kubeconfig is empty, which means that this operation has been called on a helmfile resource that depends on in-existent resource")
+
+		return nil
 	}
 
 	provider := meta.(*ProviderInstance)

--- a/pkg/helmfile/resource_release_set_test.go
+++ b/pkg/helmfile/resource_release_set_test.go
@@ -96,6 +96,8 @@ EOF
 
   helm_binary = "helm"
 
+  kubeconfig = pathexpand("~/.kube/config")
+
   working_directory = "%s"
 
   environment = "default"

--- a/pkg/helmfile/resource_release_set_test.go
+++ b/pkg/helmfile/resource_release_set_test.go
@@ -138,7 +138,7 @@ EOF
   version = "0.128.0"
   helm_version = "3.2.1"
 
-  kubeconfig_path = pathexpand("~/.kube/config")
+  kubeconfig = pathexpand("~/.kube/config")
 
   working_directory = "%s"
 

--- a/pkg/helmfile/resource_release_set_test.go
+++ b/pkg/helmfile/resource_release_set_test.go
@@ -87,6 +87,7 @@ repositories:
 releases:
 - name: pi-%s
   chart: sp/podinfo
+  version: 4.0.6
   values:
   - image:
       tag: "123"
@@ -130,6 +131,7 @@ repositories:
 releases:
 - name: pi-%s
   chart: sp/podinfo
+  version: 4.0.6
   values:
   - image:
       tag: "123"

--- a/pkg/helmfile/resource_release_set_test.go
+++ b/pkg/helmfile/resource_release_set_test.go
@@ -138,6 +138,8 @@ EOF
   version = "0.128.0"
   helm_version = "3.2.1"
 
+  kubeconfig_path = pathexpand("~/.kube/config")
+
   working_directory = "%s"
 
   environment = "default"

--- a/pkg/helmfile/resource_release_set_test.go
+++ b/pkg/helmfile/resource_release_set_test.go
@@ -137,7 +137,7 @@ releases:
     labelkey1: value1
 EOF
 
-  version = "0.128.0"
+  version = "0.128.1"
   helm_version = "3.2.1"
 
   kubeconfig = pathexpand("~/.kube/config")


### PR DESCRIPTION
This change would help us avoid potential bugs (like calling helmfile-apply on default kubeconfig rather than specified one) caused by our workaround for terraform issue that `terraform plan` on helmfile_release_set whose `kubeconfig_path` depends on not-yet-created resource.