### PR TITLE
Set kubeconfig to sensitive value

### DIFF
--- a/pkg/helmfile/resource_release.go
+++ b/pkg/helmfile/resource_release.go
@@ -4,10 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/xid"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	"runtime/debug"
+
+	"github.com/rs/xid"
+	"golang.org/x/xerrors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -108,9 +109,10 @@ func resourceHelmfileRelease() *schema.Resource {
 				Default:  0,
 			},
 			KeyKubeconfig: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  false,
+				Sensitive: true,
 			},
 			KeyKubecontext: {
 				Type:     schema.TypeString,

--- a/pkg/helmfile/resource_release_set.go
+++ b/pkg/helmfile/resource_release_set.go
@@ -2,12 +2,13 @@ package helmfile
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/rs/xid"
 	"log"
 	"os"
 	"runtime/debug"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/rs/xid"
 )
 
 const KeyValuesFiles = "values_files"
@@ -63,9 +64,10 @@ var ReleaseSetSchema = map[string]*schema.Schema{
 		Default:  "",
 	},
 	KeyKubeconfig: {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: false,
+		Type:      schema.TypeString,
+		Required:  true,
+		ForceNew:  false,
+		Sensitive: true,
 	},
 	KeyPath: {
 		Type:     schema.TypeString,


### PR DESCRIPTION
Because the kubeconfig file contains sensitive data (tokens or private keys) which should not be printed I added the sensitive flag to these resource objects. Currently the whole file is printed in the diff.